### PR TITLE
Add support for preseed uploads.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v1.0.4 (2018-04-03)
+
+Feature:
+
+  - Add support for upload preseed files.
+
 ## v1.0.3 (2018-02-08)
 
 Improvement:

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Usage
         mr_provisioner_url: "http://172.27.80.1:5000"
         mr_provisioner_auth_token: "MYSUPERFANCYTOKENFROMPROVISIONER"
         mr_provisioner_preseed_name: "danrue/erp-17.08-debian-20170727.567664d4"
+        mr_provisioner_preseed_path: "./preseeds/erp-17.08-generic"
         mr_provisioner_arch: "arm64"
         mr_provisioner_subarch: "efi"
       roles:
@@ -72,8 +73,6 @@ Caveats
 
 Most of these behaviors can be fixed but in the meantime, FYI!
 
-- The preseed uploading is not yet implemented. The preseed named in
-  mr_provisioner_preseed_name is expected to already exist in Mr. Provisioner.
 - Use unique image descriptions. The kernel and initrd files are only uploaded
   once. If they're changed locally but the description is the same, they will
   not be re-uploaded. If it finds someone else's image with the same

--- a/library/mr_provisioner_preseed.py
+++ b/library/mr_provisioner_preseed.py
@@ -1,0 +1,150 @@
+#!/usr/bin/python
+
+import json
+import requests
+
+from future.standard_library import install_aliases
+install_aliases()
+
+from urllib.parse import urljoin
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: mr-provisioner-preseed
+
+short_description: Manage preseed files in Mr. Provisioner
+
+description:
+    Implemented:
+        - Upload new preseed
+        - Discover existing preseeds by a given name.
+    Not implemented:
+        - modifying existing preseed
+        - deleting existing preseed
+
+options:
+    name:
+        description:
+            - Name of the preseed
+        required: true
+    description:
+        description:
+            - Description of the preseed
+        required: false
+    path:
+        description: Local file path to preseed file.
+        required: true
+    url:
+        description: url to provisioner instance in the form of http://172.27.80.1:5000/
+        required: true
+    token:
+        description: Mr. Provisioner auth token
+        required: true
+    known_good:
+        description: Mark known good. Default false.
+        required: false
+    public:
+        description: Mark public. Default false.
+        required: false
+
+author:
+    - Jorge Niedbalski <jorge.niedbalski@linaro.org>
+'''
+
+EXAMPLES = '''
+# Upload a preseed file to a MrProvisioner install.
+- name: moonshot-generic-preseed
+  path: ./preseeds/moonshot-generic.preseed.txt
+  url: http://172.27.80.1:5000/
+  token: "{{ provisioner_auth_token }}"
+'''
+
+RETURN = '''
+  id: auto-assigned preseed id
+  description: preseed description
+  name: preseed name
+  type: user defined type (default: preseed)
+  user: User that owns the preseed
+  known_good: true/false
+  public: true/false
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def run_module():
+    # define the available arguments/parameters that a user can pass to
+    # the module
+    module_args = dict(
+        description=dict(type='str', required=False, default=""),
+        name=dict(type='str', required=True),
+        type=dict(type='str', required=False, default="preseed"),
+        path=dict(type='str', required=True),
+        url=dict(type='str', required=True),
+        token=dict(type='str', required=True),
+        known_good=dict(type='bool', required=False, default=False),
+        public=dict(type='bool', required=False, default=False),
+    )
+
+    result = dict(
+        changed=False
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+
+    if module.check_mode:
+        return result
+    # Determine if image is already uploaded
+    headers = {'Authorization': module.params['token']}
+    url = urljoin(module.params['url'], "/api/v1/preseed?show_all=true")
+    r = requests.get(url, headers=headers)
+    if r.status_code != 200:
+        module.fail_json(msg='Error fetching {}, HTTP {} {}'.format(url,
+                         r.status_code, r.reason), **result)
+    for preseed in r.json():
+        if preseed['name'] == module.params['name']:
+            result['json'] = preseed
+            module.exit_json(**result)
+
+    headers = {'Authorization': module.params['token']}
+    url = urljoin(module.params['url'], "/api/v1/preseed")
+
+    with open(module.params['path'], 'r') as content:
+        content = content.read()
+
+    data = json.dumps({
+        'description': module.params['description'],
+        'type': module.params['type'],
+        'name': module.params['name'],
+        'known_good': module.params['known_good'],
+        'public': module.params['public'],
+        'content': content,
+    })
+
+    r = requests.post(url, data=data, headers=headers)
+    if r.status_code != 201:
+        msg = ("Error fetching {}, HTTP {} {}\nrequest data: {}\nresult json: {}".
+                format(url, r.status_code, r.reason, data, r.json()))
+        module.fail_json(msg=msg, **result)
+    result['json'] = r.json()
+    result['changed'] = True
+
+    # in the event of a successful module execution, you will want to
+    # simple AnsibleModule.exit_json(), passing the key/value results
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+if __name__ == '__main__':
+    main()

--- a/tasks/provision.yml
+++ b/tasks/provision.yml
@@ -9,6 +9,7 @@
     - mr_provisioner_url
     - mr_provisioner_auth_token
     - mr_provisioner_preseed_name
+    - mr_provisioner_preseed_path
     - mr_provisioner_arch
     - mr_provisioner_subarch
 
@@ -36,7 +37,19 @@
   run_once: true
   register: initrd_image
 - debug: var=initrd_image
-
+- name: Upload Preseed
+  mr_provisioner_preseed:
+    name: "{{ mr_provisioner_preseed_name }}"
+    description: "{{ mr_provisioner_preseed_description | default('') }}"
+    type: "{{ mr_provisioner_preseed_type | default('preseed')}}"
+    path: "{{ mr_provisioner_preseed_path }}"
+    url: "{{ mr_provisioner_url }}"
+    token: "{{ mr_provisioner_auth_token }}"
+    public: "{{ mr_provisioner_preseed_public | default(true)}}"
+    known_good: "{{ mr_provisioner_preseed_known_good | default(true)}}"
+  run_once: true
+  register: preseed
+- debug: var=preseed
 - name: Provision machine
   mr_provisioner_machine_provision:
     machine_name: "{{ inventory_hostname }}"


### PR DESCRIPTION
This commit implements a new module for adding
support to upload a preseed file given a name/path.

For now, If the given name already exists (used as the primary key)
then the upload is ignored, if the name doesn't exists yet
then the new preseed is uploaded from the given local path.