### PR TITLE
Append to Pass Kernel Options

### DIFF
--- a/library/mr_provisioner_machine_provision.py
+++ b/library/mr_provisioner_machine_provision.py
@@ -101,7 +101,7 @@ def machine_provision(url, token, machine_id):
 
 
 def set_machine_parameters(url, token, machine_id, initrd_id=None,
-                           kernel_id=None, preseed_id=None, subarch=None):
+                           kernel_id=None, kernel_opts="", preseed_id=None, subarch=None):
     """ Set parameters on machine specified by machine_id """
     headers = {'Authorization': token}
     url = urljoin(url, "/api/v1/machine/{}".format(machine_id))
@@ -115,8 +115,10 @@ def set_machine_parameters(url, token, machine_id, initrd_id=None,
         parameters['preseed_id'] = preseed_id
     if subarch:
         parameters['subarch'] = subarch
+    if kernel_opts:
+        parameters['kernel_opts'] = kernel_opts
+
     parameters['netboot_enabled'] = True
-    parameters['kernel_opts'] = ""
 
     data = json.dumps(parameters)
 
@@ -249,6 +251,7 @@ def run_module():
                                       machine_id=machine['id'],
                                       initrd_id=initrd_id['id'],
                                       kernel_id=kernel_id['id'],
+                                      kernel_opts=module.params['kernel_options'],
                                       preseed_id=preseed['id'],
                                       subarch=module.params['subarch'])
 


### PR DESCRIPTION
Sadly I wasn't able to find how to add something to Jorge's pull request (#3 )... 
Sorry Jorge !

I modified mr_provisioner_machine_provision.py to support kernel opts and added default kernel option as an empty string.