### PR TITLE
Add fetching of provisioned machine's IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,13 @@ required:
 - ``mr_provisioner_auth_token``: Auth token from Mr. Provisioner.
 - ``mr_provisioner_arch``: Image architecture.
 - ``mr_provisioner_subarch``: Machine subarchitecture.
-- ``machine_user``: Machine SSH user that wait_for_connection should try authenticating as.
 
 Usage
 -----
 
     - hosts: provision_this_machine
       vars:
-	mr_provisioner_machine_name: "if you don't assign it, it will use inventory hostname"
+        mr_provisioner_machine_name: "if you don't assign it, it will use inventory hostname"
         mr_provisioner_kernel_description: "debian-installer staging build 495"
         mr_provisioner_initrd_description: "debian-installer staging build 495"
         mr_provisioner_kernel_path: "./builds/debian-staging/495/linux"
@@ -48,17 +47,15 @@ Usage
         mr_provisioner_preseed_path: "./preseeds/erp-17.08-generic"
         mr_provisioner_arch: "arm64"
         mr_provisioner_subarch: "efi"
-	machine_user: "myspecialuser"
       roles:
         - role: Linaro.mr-provisioner
 
-    - hosts: target
-      gather_facts: no
+    - hosts: mr_provisoner_hosts
       tasks:
-		- name: Wait for host for 3600 seconds, but only start checking after 60.
-		  wait_for_connection:
-			delay: 60
-			timeout: 3600
+        - name: Wait for host for 3600 seconds, but only start checking after 60.
+          wait_for_connection:
+            delay: 60
+            timeout: 3600
 
 Role Modules
 ------------

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ tasks. This is useful if all you want is the modules.
 
 If mr_provisioner_do_provision is set, all of the following variables are
 required:
+- ``mr_provisioner_machine_name``: Machine's name.
 - ``mr_provisioner_kernel_description``: Unique kernel description to use in
   provisioner.
 - ``mr_provisioner_initrd_description``: Unique initrd description to use in
@@ -29,13 +30,14 @@ required:
 - ``mr_provisioner_auth_token``: Auth token from Mr. Provisioner.
 - ``mr_provisioner_arch``: Image architecture.
 - ``mr_provisioner_subarch``: Machine subarchitecture.
-
+- ``machine_user``: Machine SSH user that wait_for_connection should try authenticating as.
 
 Usage
 -----
 
-    - hosts: all
+    - hosts: provision_this_machine
       vars:
+	mr_provisioner_machine_name: "if you don't assign it, it will use inventory hostname"
         mr_provisioner_kernel_description: "debian-installer staging build 495"
         mr_provisioner_initrd_description: "debian-installer staging build 495"
         mr_provisioner_kernel_path: "./builds/debian-staging/495/linux"
@@ -46,16 +48,27 @@ Usage
         mr_provisioner_preseed_path: "./preseeds/erp-17.08-generic"
         mr_provisioner_arch: "arm64"
         mr_provisioner_subarch: "efi"
+	machine_user: "myspecialuser"
       roles:
         - role: Linaro.mr-provisioner
+
+    - hosts: target
+      gather_facts: no
+      tasks:
+		- name: Wait for host for 3600 seconds, but only start checking after 60.
+		  wait_for_connection:
+			delay: 60
+			timeout: 3600
 
 Role Modules
 ------------
 
-This role contains two ansible modules:
-- ``mr_provisioner_image``: Handle uploading image files to Mr. Provisioner.
-- ``mr_provisioner_machine_provision``: Handle provisioning a host in Mr.
+This role contains four ansible modules:
+- ``mr_provisioner_image``: Handles uploading image files to Mr. Provisioner.
+- ``mr_provisioner_machine_provision``: Handles provisioning a host in Mr.
   Provisioner.
+- ``mr_provisioner_preseed``: Handles uploading preseed files to Mr. Provisioner.
+- ``mr_provisioner_get_ip``: Handles fetching the provisioned machine's IP from Mr. Provisioner.
 
 By default, these modules are used by the tasks in the role. They may also be
 used outside the role if the included role tasks are not suitable.
@@ -78,8 +91,6 @@ Most of these behaviors can be fixed but in the meantime, FYI!
   not be re-uploaded. If it finds someone else's image with the same
   description, it will use it. If there are multiple images with the same
   description, it will use the first one found (non deterministically).
-- It does not retrieve the IP of the host from Mr. Provisioner. The IP should
-  be set in ansible inventory.
 
 See Also
 --------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,4 +5,4 @@ mr_provisioner_do_provision: True
 
 # By default, do not fetch the ip of the provisioned machine
 # Instead defer it to the host file, as legacy interface does.
-mr_provisioner_machine_name: False
+mr_provisioner_machine_name: "{{ inventory_hostname }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,8 @@
----
-
 # By default, upload images and provision a host
 # Disable mr_provisioner_do_provision to skip the tasks
 # and just use the included modules
 mr_provisioner_do_provision: True
+
+# By default, do not fetch the ip of the provisioned machine
+# Instead defer it to the host file, as legacy interface does.
+mr_provisioner_machine_name: False

--- a/library/mr_provisioner_get_ip.py
+++ b/library/mr_provisioner_get_ip.py
@@ -116,9 +116,6 @@ class IPGetter(object):
 
         for i in interfaces:
             if str(i['identifier']) == self.interface:
-                if str(i['config_type_v4']) == 'dynamic-reserved' and str(i['configured_ipv4']):
-                    return i['configured_ipv4']
-                else:
                     return i['lease_ipv4']
 
 def get_machine_by_name(mrp_token, mrp_url, machine_name):

--- a/library/mr_provisioner_get_ip.py
+++ b/library/mr_provisioner_get_ip.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python2.7
+# -*- coding: utf-8 -*-
+
+import requests
+import json
+try:
+    from urllib.parse import urljoin
+except ImportError:
+    from urlparse import urljoin
+try:
+        from urllib import quote  # Python 2.X
+except ImportError:
+        from urllib.parse import quote  # Python 3+
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: mr_provisioner_get_ip
+
+short_description: This is a short module fetching the ip of the machine being
+provisioned from MrP. It should be then used to create a new host (dynamically)
+and then do the wait_for_connection on that new host. (sadly to do that one
+needs to go all the way back to the playbook).
+
+version_added: "1.0"
+
+description:
+    - "This module has been designed to compliment the provisioning role,
+    making it able to fetch the IP from MrP, making use of the available API
+    for it. It should be noted that the current behaviour is of fetching the
+    reserved address for an dynamic-reserved interface. If it's static or
+    dynamic, the module will fetch the last address given by KEA"
+
+options:
+    mrp_url:
+        description:
+            - This is the URL of the Mr Provisioner
+        required: true
+    mrp_token:
+        description:
+            - This is the authentication token for MrP's API
+        required: true
+    machine_name:
+        description:
+            - This is the machine name as shown in MrP
+        required: true
+    interface_name:
+        description:
+            - This is the name of the machine's interface you'd like the IP of.
+        required: true
+
+author:
+    - Baptiste Gerondeau (baptiste.gerondeau@linaro.org)
+'''
+
+EXAMPLES = '''
+- name: Get IP of provisioned machine
+  mr_provisioner_get_ip:
+    mrp_url: "{{ mr_provisioner_url }}"
+    mrp_token: "{{ mr_provisioner_auth_token }}"
+    machine_name: "{{ mr_provisioner_machine_name }}"
+    interface_name: "{{ mr_provisioner_interface_name|default('eth1') }}"
+  register: get_ip
+- debug: var=get_ip
+
+#Note that you get the ip fetched via get_ip['ip'] : you NEED to register get_ip
+#This seems overly complicated but I've found no other way to do it...
+'''
+
+RETURN = '''
+ip:
+    description: An.... IP !! (v4 because MrP doesn't do v6)
+    type: str
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+
+class ProvisionerError(Exception):
+    def __init__(self, message):
+        super(ProvisionerError, self).__init__(message)
+
+class IPGetter(object):
+    def __init__(self, mrpurl, mrptoken, machine_id, interface_name =
+                 'eth1'):
+        self.mrp_url = mrpurl
+        self.mrp_token = mrptoken
+        self.interface = interface_name
+        self.machine_id = machine_id
+        self.machine_ip = ''
+
+    def get_interfaces(self):
+        headers = {'Authorization': self.mrp_token}
+        url = urljoin(self.mrp_url,
+                      "/api/v1/machine/{}/interface".format(self.machine_id))
+        r = requests.get(url, headers=headers)
+        if r.status_code != 200:
+            raise ProvisionerError('Error fetching {}, HTTP {} {}'.format(self.mrp_url, r.status_code,
+                                                         r.reason))
+        if len(r.json()) == 0:
+            raise ProvisionerError('Error no machine with id "{}"'.format(self.machine_id))
+
+        return r.json()
+
+    def get_ip(self):
+        try:
+            interfaces = self.get_interfaces()
+        except ProvisionerError as e:
+            print('Could not fetch interface for machine : "{}"'.format(e))
+            return 'FAILURE'
+
+        for i in interfaces:
+            if str(i['identifier']) == self.interface:
+                if str(i['config_type_v4']) == 'dynamic-reserved' and str(i['configured_ipv4']):
+                    return i['configured_ipv4']
+                else:
+                    return i['lease_ipv4']
+
+def get_machine_by_name(mrp_token, mrp_url, machine_name):
+    """ Look up machine by name """
+    headers = {'Authorization': mrp_token}
+    q = '(= name "{}")'.format(quote(machine_name))
+    url = urljoin(mrp_url, "/api/v1/machine?q={}&show_all=false".format(q))
+    r = requests.get(url, headers=headers)
+    if r.status_code != 200:
+        raise ProvisionerError('Error fetching {}, HTTP {} {}'.format(mrp_url,
+                         r.status_code, r.reason))
+    if len(r.json()) == 0:
+       raise ProvisionerError('Error no assigned machine found with name "{}"'.
+                    format(machine_name))
+    if len(r.json()) > 1:
+       raise ProvisionerError('Error more than one machine found with name "{}", {}'.
+                    format(machine_name, r.json()))
+    return r.json()[0]
+
+def run_module():
+    module_args = dict(
+        mrp_url = dict(type='str', required=True),
+        mrp_token = dict(type='str', required=True),
+        machine_name = dict(type='str', required=True),
+        interface_name = dict(type='str', required=False),
+    )
+
+    result = dict(
+        changed=False,
+        debug={},
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    if module.check_mode:
+        return result
+
+    machine_id = get_machine_by_name(module.params['mrp_token'],
+                                     module.params['mrp_url'],
+                                     module.params['machine_name'])['id']
+
+    if module.params['interface_name']:
+        ipgetter = IPGetter(module.params['mrp_url'], module.params['mrp_token'],
+                            machine_id,
+                            module.params['interface_name'])
+    else:
+        ipgetter = IPGetter(module.params['mrp_url'], module.params['mrp_token'],
+                            machine_id)
+    try:
+        machine_ip = str(ipgetter.get_ip())
+    except ProvisionerError as e:
+        module.fail_json(msg='Could not get IP error : "{}"'.format(e),
+                         **result)
+
+    if machine_ip:
+        result['ip'] = machine_ip
+        result['json'] = { 'status': 'ok' }
+        result['changed'] = True
+    else:
+        module.fail_json(msg='Failure to fetch IP from MrP', **result)
+
+    module.exit_json(**result)
+
+def main():
+    run_module()
+
+if __name__ == '__main__':
+    main()
+

--- a/library/mr_provisioner_image.py
+++ b/library/mr_provisioner_image.py
@@ -6,7 +6,10 @@ import requests
 from future.standard_library import install_aliases
 install_aliases()
 
-from urllib.parse import urljoin
+try:
+    from urlparse import urljoin    #Python2
+except ImportError:
+    from urllib.parse import urljoin    #Python3
 
 ANSIBLE_METADATA = {
     'metadata_version': '1.1',

--- a/library/mr_provisioner_machine_provision.py
+++ b/library/mr_provisioner_machine_provision.py
@@ -6,8 +6,15 @@ import requests
 from future.standard_library import install_aliases
 install_aliases()
 
-from urllib.parse import urljoin
-from urllib import quote
+try:
+    from urlparse import urljoin    #Python2
+except ImportError:
+    from urllib.parse import urljoin    #Python3
+
+try:
+    from urllib import quote
+except ImportError:
+    from urllib.parse import quote
 
 ANSIBLE_METADATA = {
     'metadata_version': '1.1',
@@ -205,7 +212,7 @@ def run_module():
         machine = get_machine_by_name(module.params['url'],
                                       module.params['token'],
                                       module.params['machine_name'])
-    except ProvisionerError, e:
+    except ProvisionerError as e:
         module.fail_json(msg=str(e), **result)
     result['debug']['machine'] = machine
 
@@ -221,7 +228,7 @@ def run_module():
                                          "Initrd",
                                          module.params['initrd_description'],
                                          module.params['arch'])
-    except ProvisionerError, e:
+    except ProvisionerError as e:
         module.fail_json(msg=str(e), **result)
     result['debug']['kernel_id'] = kernel_id
     result['debug']['initrd_id'] = initrd_id
@@ -231,7 +238,7 @@ def run_module():
         preseed = get_preseed_by_name(module.params['url'],
                                       module.params['token'],
                                       module.params['preseed_name'])
-    except ProvisionerError, e:
+    except ProvisionerError as e:
         module.fail_json(msg=str(e), **result)
     result['debug']['preseed'] = preseed
 
@@ -245,7 +252,7 @@ def run_module():
                                       preseed_id=preseed['id'],
                                       subarch=module.params['subarch'])
 
-    except ProvisionerError, e:
+    except ProvisionerError as e:
         module.fail_json(msg=str(e), **result)
     result['machine_state'] = machine_state
 
@@ -255,7 +262,7 @@ def run_module():
                                       module.params['token'],
                                       machine_id=machine['id'])
 
-    except ProvisionerError, e:
+    except ProvisionerError as e:
         module.fail_json(msg=str(e), **result)
     result['machine_provision'] = machine_state
 

--- a/tasks/add_host.yml
+++ b/tasks/add_host.yml
@@ -1,0 +1,20 @@
+- name: Verify variables are set
+  assert:
+    that: "{{ item }} is defined"
+  with_items:
+    - mr_provisioner_machine_name
+
+- name: Get IP of provisioned machine
+  mr_provisioner_get_ip:
+    mrp_url: "{{ mr_provisioner_url }}"
+    mrp_token: "{{ mr_provisioner_auth_token }}"
+    machine_name: "{{ mr_provisioner_machine_name }}"
+    interface_name: "{{ mr_provisioner_interface_name|default('eth1') }}"
+  register: get_ip
+- debug: var=get_ip
+
+- name: Add provisioned machine as host
+  add_host:
+          name: "{{ get_ip['ip'] }}"
+          groups: mr_provisioner_hosts
+  when: get_ip['ip'] is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,13 @@
 - include: provision.yml
   when: mr_provisioner_do_provision
   delegate_to: localhost
+- debug: var=mr_provisioner_machine_name
+
+- include: add_host.yml
+  when: mr_provisioner_machine_name != False
+
+- name: Wait for host for 3600 seconds, but only start checking after 60 seconds
+  wait_for_connection:
+    delay: 60
+    timeout: 3600
+  when: mr_provisioner_do_provision and not mr_provisioner_machine_name

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,4 +10,4 @@
   wait_for_connection:
     delay: 60
     timeout: 3600
-  when: mr_provisioner_do_provision and mr_provisioner_machine_name != inventory_hostname
+  when: mr_provisioner_do_provision and mr_provisioner_machine_name == inventory_hostname

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,3 @@
 - include: provision.yml
   when: mr_provisioner_do_provision
   delegate_to: localhost
-
-- name: Wait for host for 3600 seconds, but only start checking after 60 seconds
-  wait_for_connection:
-    delay: 60
-    timeout: 3600
-  when: mr_provisioner_do_provision

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,13 +1,13 @@
 - include: provision.yml
   when: mr_provisioner_do_provision
   delegate_to: localhost
-- debug: var=mr_provisioner_machine_name
 
 - include: add_host.yml
-  when: mr_provisioner_machine_name != False
-
+  when: mr_provisioner_machine_name != False and mr_provisioner_do_provision
+  delegate_to: localhost
+  
 - name: Wait for host for 3600 seconds, but only start checking after 60 seconds
   wait_for_connection:
     delay: 60
     timeout: 3600
-  when: mr_provisioner_do_provision and not mr_provisioner_machine_name
+  when: mr_provisioner_do_provision and mr_provisioner_machine_name

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,11 +3,11 @@
   delegate_to: localhost
 
 - include: add_host.yml
-  when: mr_provisioner_machine_name != False and mr_provisioner_do_provision
+  when: mr_provisioner_machine_name != inventory_hostname and mr_provisioner_do_provision
   delegate_to: localhost
   
 - name: Wait for host for 3600 seconds, but only start checking after 60 seconds
   wait_for_connection:
     delay: 60
     timeout: 3600
-  when: mr_provisioner_do_provision and mr_provisioner_machine_name
+  when: mr_provisioner_do_provision and mr_provisioner_machine_name != inventory_hostname

--- a/tasks/provision.yml
+++ b/tasks/provision.yml
@@ -10,6 +10,7 @@
     - mr_provisioner_url
     - mr_provisioner_auth_token
     - mr_provisioner_preseed_name
+    - mr_provisioner_preseed_path
     - mr_provisioner_arch
     - mr_provisioner_subarch
 
@@ -55,6 +56,7 @@
     machine_name: "{{ mr_provisioner_machine_name }}"
     kernel_description: "{{ mr_provisioner_kernel_description }}"
     initrd_description: "{{ mr_provisioner_initrd_description }}"
+    kernel_options: "{{ mr_provisioner_kernel_options|default('') }}"
     arch: "{{ mr_provisioner_arch }}"
     subarch: "{{ mr_provisioner_subarch }}"
     preseed_name: "{{ mr_provisioner_preseed_name }}"

--- a/tasks/provision.yml
+++ b/tasks/provision.yml
@@ -55,7 +55,6 @@
     machine_name: "{{ mr_provisioner_machine_name }}"
     kernel_description: "{{ mr_provisioner_kernel_description }}"
     initrd_description: "{{ mr_provisioner_initrd_description }}"
-    kernel_options: "{{ mr_provisioner_kernel_options|default('') }}"
     arch: "{{ mr_provisioner_arch }}"
     subarch: "{{ mr_provisioner_subarch }}"
     preseed_name: "{{ mr_provisioner_preseed_name }}"
@@ -63,19 +62,3 @@
     token: "{{ mr_provisioner_auth_token }}"
   register: provision_machine
 - debug: var=provision_machine
-
-- name: Get IP of provisioned machine
-  mr_provisioner_get_ip:
-    mrp_url: "{{ mr_provisioner_url }}"
-    mrp_token: "{{ mr_provisioner_auth_token }}"
-    machine_name: "{{ mr_provisioner_machine_name }}"
-    interface_name: "{{ mr_provisioner_interface_name|default('eth1') }}"
-  register: get_ip
-- debug: var=get_ip
-
-- name: Add provisioned machine as host
-  add_host:
-          name: "{{ get_ip['ip'] }}"
-          groups: target
-          ansible_user: "{{ machine_user | default('root') }}"
-  when: get_ip['ip'] is defined

--- a/tasks/provision.yml
+++ b/tasks/provision.yml
@@ -2,6 +2,7 @@
   assert:
     that: "{{ item }} is defined"
   with_items:
+    - mr_provisioner_machine_name
     - mr_provisioner_kernel_description
     - mr_provisioner_initrd_description
     - mr_provisioner_kernel_path
@@ -9,7 +10,6 @@
     - mr_provisioner_url
     - mr_provisioner_auth_token
     - mr_provisioner_preseed_name
-    - mr_provisioner_preseed_path
     - mr_provisioner_arch
     - mr_provisioner_subarch
 
@@ -52,9 +52,10 @@
 - debug: var=preseed
 - name: Provision machine
   mr_provisioner_machine_provision:
-    machine_name: "{{ inventory_hostname }}"
+    machine_name: "{{ mr_provisioner_machine_name }}"
     kernel_description: "{{ mr_provisioner_kernel_description }}"
     initrd_description: "{{ mr_provisioner_initrd_description }}"
+    kernel_options: "{{ mr_provisioner_kernel_options|default('') }}"
     arch: "{{ mr_provisioner_arch }}"
     subarch: "{{ mr_provisioner_subarch }}"
     preseed_name: "{{ mr_provisioner_preseed_name }}"
@@ -62,3 +63,19 @@
     token: "{{ mr_provisioner_auth_token }}"
   register: provision_machine
 - debug: var=provision_machine
+
+- name: Get IP of provisioned machine
+  mr_provisioner_get_ip:
+    mrp_url: "{{ mr_provisioner_url }}"
+    mrp_token: "{{ mr_provisioner_auth_token }}"
+    machine_name: "{{ mr_provisioner_machine_name }}"
+    interface_name: "{{ mr_provisioner_interface_name|default('eth1') }}"
+  register: get_ip
+- debug: var=get_ip
+
+- name: Add provisioned machine as host
+  add_host:
+          name: "{{ get_ip['ip'] }}"
+          groups: target
+          ansible_user: "{{ machine_user | default('root') }}"
+  when: get_ip['ip'] is defined


### PR DESCRIPTION
This module adds the support for fetching the provisioned machine's IP from MrP to then feed it to wait_for_connection. Thus, the initial role is executed with "hosts: localhost".

The user used by wait_for_connection must be in the ansible_user option of the host definition, and that is done in the last task of provision.yml and set by machine_user (or root by default).
Please ensure that the preseed you fetch to the machine has the necessary keys, else wait_for_connection will fail. (but you can modify that preseed now so it shouldn't be a problem !)